### PR TITLE
refactor(user-service): Update token cleanup response message to portuguese

### DIFF
--- a/OwnLight.UserService/UserService.API/Controllers/AdminController.cs
+++ b/OwnLight.UserService/UserService.API/Controllers/AdminController.cs
@@ -34,6 +34,6 @@ public class AdminController(IMediator mediator, TokenCleanupStateService tokenC
             return Ok(formattedLastRun);
         }
 
-        return Ok("No cleanup has been run yet.");
+        return Ok("Nenhuma limpaza de token foi realizada ainda");
     }
 }


### PR DESCRIPTION
This pull request includes a small change to the `OwnLight.UserService/UserService.API/Controllers/AdminController.cs` file. The change updates the response message in the `GetLastTokenCleanupRun` method to Portuguese.

* [`OwnLight.UserService/UserService.API/Controllers/AdminController.cs`](diffhunk://#diff-78d87973281590f80d94cbc33fac44de609f05c8071e0a951efbf61a0ad60b96L37-R37): Changed the response message from "No cleanup has been run yet." to "Nenhuma limpaza de token foi realizada ainda" in the `GetLastTokenCleanupRun` method.